### PR TITLE
removed foolday/poolday map from the playlist

### DIFF
--- a/dist/hl2mp/cfg/mapcycle.txt
+++ b/dist/hl2mp/cfg/mapcycle.txt
@@ -3,7 +3,6 @@ dm_bk_lambda_box_rc1
 dm_bwo_parking_np
 dm_crossfire_final
 dm_datacore
-dm_fool_day
 DM_Gothic_UTclassic_v7b
 dm_greenhouse
 dm_lockdown


### PR DESCRIPTION
removed foolday/poolday map from the playlist. Had lag issue at recent 2025 summer event. 